### PR TITLE
fix: dialog 重做 & Slider 样式修复 & RippleEffect 新增 clearAllRippleAnimate 全局方法

### DIFF
--- a/packages/button/BasicButton.vue
+++ b/packages/button/BasicButton.vue
@@ -34,6 +34,7 @@ const onClick = () => {
     padding: 0;
     border: 0;
     border-radius: 0;
+    outline: none;
     font-family: inherit;
     font-style: inherit;
     font-variant: inherit;

--- a/packages/dialog/InputDialog.vue
+++ b/packages/dialog/InputDialog.vue
@@ -1,23 +1,28 @@
 <template>
-    <salt-basic-dialog v-model:open="open" class-name="salt-input-dialog" :close-on-outside-click="closeOnOutsideClick"
-        :teleport="teleport">
-        <slat-dialog-title :text="title"></slat-dialog-title>
+    <salt-basic-dialog v-model:open="open" class="salt-input-dialog" :close-on-outside-click="closeOnOutsideClick"
+        @open="emit('open')" @close="emit('close')">
+        <salt-item-out-spacer />
+        <slat-dialog-title :text="title" />
 
-        <salt-item-edit v-model="model" @change="onChange"></salt-item-edit>
+        <div class="salt-item-edit-container">
+            <salt-item-edit v-model="model" @change="onChange" />
+        </div>
 
         <form class="actions" method="dialog">
-            <salt-text-button class="cancel" @click="onCancel" text="CANCEL"></salt-text-button>
+            <salt-text-button class="cancel" @click="emit('cancel')" text="CANCEL" />
             <div class="spacer-width"></div>
-            <salt-text-button class="confirm" @click="onConfirm" text="CONFIRM"></salt-text-button>
+            <salt-text-button class="confirm" @click="emit('confirm')" text="CONFIRM" />
         </form>
+
+        <salt-item-out-spacer />
     </salt-basic-dialog>
 </template>
   
 <script setup lang="ts">
 import { ModelRef } from 'vue';
-import { SlatDialogTitle, SaltBasicDialog, SaltItemEdit, SaltTextButton } from '../../packages'
+import { SlatDialogTitle, SaltBasicDialog, SaltItemEdit, SaltItemOutSpacer, SaltTextButton } from '../../packages'
 
-const open = defineModel('open') as ModelRef<Boolean>;
+const open = defineModel('open') as ModelRef<boolean>;
 const model = defineModel() as ModelRef<String>;
 
 defineProps({
@@ -33,32 +38,20 @@ defineProps({
         required: false,
         default: true
     },
-    /**
-     * 指定挂载的节点，等同于 Teleport 组件的 to 属性
-     */
-    teleport: {
-        type: String,
-        required: false
-    }
 })
 
-const emit = defineEmits(['change', 'confirm', 'cancel', 'dismissRequest'])
+const emit = defineEmits(['change', 'open', 'close', 'confirm', 'cancel'])
 
 const onChange = (event: Event) => {
     emit('change', event)
 }
-
-const onCancel = () => {
-    emit('dismissRequest')
-    emit('cancel')
-}
-
-const onConfirm = () => {
-    emit('confirm')
-}
 </script>
   
 <style>
+.salt-input-dialog .salt-item-edit-container {
+    padding: 4px 0;
+}
+
 .salt-input-dialog .actions {
     display: flex;
     flex-direction: row;
@@ -70,6 +63,11 @@ const onConfirm = () => {
 
 .salt-input-dialog .spacer-width {
     width: var(--salt-dimen-outer-horizontal-padding);
+}
+
+.salt-input-dialog .salt-basic-button.salt-text-button button {
+    position: relative;
+    z-index: 1;
 }
 
 .salt-input-dialog .salt-basic-button.salt-text-button.cancel button {

--- a/packages/dialog/YesDialog.vue
+++ b/packages/dialog/YesDialog.vue
@@ -1,21 +1,30 @@
 <template>
-    <salt-basic-dialog v-model:open="open" class-name="salt-yes-dialog" :close-on-outside-click="closeOnOutsideClick"
-        :teleport="teleport">
-        <slat-dialog-title :text="title"></slat-dialog-title>
+    <salt-basic-dialog v-model:open="open" class="salt-yes-dialog" :close-on-outside-click="closeOnOutsideClick"
+        @open="emit('open')" @close="emit('close')">
+        <salt-item-out-spacer />
+        <slat-dialog-title :text="title" />
+        <salt-item-out-spacer />
 
-        <slot><salt-item-text :text="content"></salt-item-text></slot>
+        <slot>
+            <salt-item-text :text="content" />
+            <salt-item-out-half-spacer />
+            <!-- drawContent?.invoke() -->
+            <salt-item-out-half-spacer />
+        </slot>
 
         <form class="actions" method="dialog">
-            <salt-text-button class="confirm" @click="onConfirm" :text="text.toUpperCase()"></salt-text-button>
+            <salt-text-button class="confirm" @click="emit('confirm')" :text="text.toUpperCase()" />
         </form>
+
+        <salt-item-out-spacer />
     </salt-basic-dialog>
 </template>
   
 <script setup lang="ts">
 import { ModelRef } from 'vue';
-import { SlatDialogTitle, SaltBasicDialog, SaltItemText, SaltTextButton } from '../../packages'
+import { SlatDialogTitle, SaltBasicDialog, SaltItemText, SaltItemOutSpacer, SaltItemOutHalfSpacer, SaltTextButton } from '../../packages'
 
-const open = defineModel('open') as ModelRef<Boolean>;
+const open = defineModel('open') as ModelRef<boolean>;
 
 defineProps({
     title: {
@@ -38,21 +47,10 @@ defineProps({
         type: Boolean,
         required: false,
         default: true
-    },
-    /**
-     * 指定挂载的节点，等同于 Teleport 组件的 to 属性
-     */
-    teleport: {
-        type: String,
-        required: false
     }
 })
 
-const emit = defineEmits(['dismissRequest'])
-
-const onConfirm = () => {
-    emit('dismissRequest')
-}
+const emit = defineEmits(['open', 'close', 'confirm'])
 </script>
   
 <style>
@@ -63,5 +61,10 @@ const onConfirm = () => {
     width: 100%;
 
     padding: 0 var(--salt-dimen-outer-horizontal-padding);
+}
+
+.salt-yes-dialog .salt-basic-button.salt-text-button button {
+    position: relative;
+    z-index: 1;
 }
 </style>

--- a/packages/dialog/YesNoDialog.vue
+++ b/packages/dialog/YesNoDialog.vue
@@ -1,23 +1,32 @@
 <template>
-    <salt-basic-dialog v-model:open="open" class-name="salt-yes-no-dialog" :close-on-outside-click="closeOnOutsideClick"
-        :teleport="teleport">
-        <slat-dialog-title :text="title"></slat-dialog-title>
+    <salt-basic-dialog v-model:open="open" class="salt-yes-no-dialog" :close-on-outside-click="closeOnOutsideClick"
+        @open="emit('open')" @close="emit('close')">
+        <salt-item-out-spacer />
+        <slat-dialog-title :text="title" />
+        <salt-item-out-spacer />
 
-        <slot><salt-item-text :text="content"></salt-item-text></slot>
+        <slot>
+            <salt-item-text :text="content" />
+            <salt-item-out-half-spacer />
+            <!-- drawContent?.invoke() -->
+            <salt-item-out-half-spacer />
+        </slot>
 
         <form class="actions" method="dialog">
-            <salt-text-button class="cancel" @click="onCancel" :text="cancelText.toUpperCase()"></salt-text-button>
+            <salt-text-button class="cancel" @click="emit('cancel')" :text="cancelText.toUpperCase()" />
             <div class="spacer-width"></div>
-            <salt-text-button class="confirm" @click="onConfirm" :text="confirmText.toUpperCase()"></salt-text-button>
+            <salt-text-button class="confirm" @click="emit('confirm')" :text="confirmText.toUpperCase()" />
         </form>
+
+        <salt-item-out-spacer />
     </salt-basic-dialog>
 </template>
   
 <script setup lang="ts">
 import { ModelRef } from 'vue';
-import { SlatDialogTitle, SaltBasicDialog, SaltItemText, SaltTextButton } from '../../packages'
+import { SlatDialogTitle, SaltBasicDialog, SaltItemText, SaltItemOutSpacer, SaltItemOutHalfSpacer, SaltTextButton } from '../../packages'
 
-const open = defineModel('open') as ModelRef<Boolean>;
+const open = defineModel('open') as ModelRef<boolean>;
 
 defineProps({
     title: {
@@ -45,26 +54,10 @@ defineProps({
         type: Boolean,
         required: false,
         default: true
-    },
-    /**
-     * 指定挂载的节点，等同于 Teleport 组件的 to 属性
-     */
-    teleport: {
-        type: String,
-        required: false
     }
 })
 
-const emit = defineEmits(['confirm', 'cancel', 'dismissRequest'])
-
-const onCancel = () => {
-    emit('dismissRequest')
-    emit('cancel')
-}
-
-const onConfirm = () => {
-    emit('confirm')
-}
+const emit = defineEmits(['open', 'close', 'confirm', 'cancel'])
 </script>
   
 <style>
@@ -79,6 +72,11 @@ const onConfirm = () => {
 
 .salt-yes-no-dialog .spacer-width {
     width: var(--salt-dimen-outer-horizontal-padding);
+}
+
+.salt-yes-no-dialog .salt-basic-button.salt-text-button button {
+    position: relative;
+    z-index: 1;
 }
 
 .salt-yes-no-dialog .salt-basic-button.salt-text-button.cancel button {

--- a/packages/item/ItemText.vue
+++ b/packages/item/ItemText.vue
@@ -19,6 +19,6 @@ defineProps({
     line-height: var(--salt-text-style-sub-line-height);
 
     width: 100%;
-    padding: var(--salt-dimen-inner-horizontal-padding);
+    padding: 0 var(--salt-dimen-inner-horizontal-padding);
 }
 </style>

--- a/packages/ripple/RippleEffect.vue
+++ b/packages/ripple/RippleEffect.vue
@@ -3,8 +3,9 @@
         <slot></slot>
         <transition-group v-if="enabled">
             <template v-for="(val, i) in ripples">
-                <span class="ripple" v-bind:ref="'ripple-' + i" :key="'ripple' + i" v-if="val.show === true"
-                    :style="{ top: val.y + 'px', left: val.x + 'px', mixBlendMode }" v-on:animationend="rippleEnd(i)">
+                <span class="salt_ripple-effect__ripple_item" v-bind:ref="'ripple-' + i" :key="'ripple' + i"
+                    v-if="val.show === true" :style="{ top: val.y + 'px', left: val.x + 'px', mixBlendMode }"
+                    v-on:animationend="rippleEnd(i)">
                 </span>
             </template>
         </transition-group>
@@ -13,9 +14,27 @@
 
 <script setup lang="ts">
 // FIXME: 当外层有圆角时，效果会超出圆角范围，需要修复
-// FIXME: 当页面跳转后并返回时，效果会继续播放，需要修复
 import { ref } from 'vue';
 import type * as CSS from 'csstype';
+
+declare global {
+    interface Window {
+        SaltUI: {
+            clearAllRippleAnimate: () => void;
+        }
+    }
+}
+
+window.SaltUI = window.SaltUI || {
+    clearAllRippleAnimate: () => {
+        ripples.value = [];
+
+        const elements = document.getElementsByClassName('salt_ripple-effect__ripple_item')
+        for (let i = 0; i < elements.length; i++) {
+            elements[i].remove()
+        }
+    }
+};
 
 defineProps({
     enabled: {
@@ -70,7 +89,7 @@ const rippleEnd = function (i: number) {
     z-index: 1;
 }
 
-.salt_ripple-effect .ripple {
+.salt_ripple-effect .salt_ripple-effect__ripple_item {
     background-color: var(--salt-color-text);
     width: 1rem;
     height: 1rem;
@@ -79,11 +98,11 @@ const rippleEnd = function (i: number) {
     transform: translateX(-100%) translateY(-100%);
 }
 
-.salt_ripple-effect.mix-blend-screen-mode .ripple {
+.salt_ripple-effect.mix-blend-screen-mode .salt_ripple-effect__ripple_item {
     animation: ripple 1250ms ease-out forwards, screen-fade 1500ms ease-out forwards;
 }
 
-.salt_ripple-effect.mix-blend-exclusion-mode .ripple {
+.salt_ripple-effect.mix-blend-exclusion-mode .salt_ripple-effect__ripple_item {
     animation: ripple 1250ms ease-out forwards, exclusion-fade 1500ms ease-out forwards;
 }
 

--- a/packages/slider/Slider.vue
+++ b/packages/slider/Slider.vue
@@ -3,13 +3,12 @@
         <div class="bar" ref="element">
             <div class="thumb" :style="{ left: position + 'px' }" @mousedown="dragStart" @touchstart="dragStart">
             </div>
-            <div class="track" :style="{ width: position + 23 + 'px' }"></div>
+            <div class="track" :style="{ width: position + 22 + 'px' }"></div>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
-// FIXME: 左上角有部分背景色没有被完成覆盖
 import { ModelRef, onMounted, ref } from 'vue';
 
 const model = defineModel() as ModelRef<number>
@@ -164,7 +163,7 @@ const dragEnd = () => {
 <style scoped>
 .salt-slider {
     --salt-slider-thumb-size: 24px;
-    --salt-slider-track-height: 23px;
+    --salt-slider-track-height: 22px;
 }
 
 .salt-slider .bar {
@@ -182,6 +181,8 @@ const dragEnd = () => {
     border-radius: 50%;
     background-color: #ffffff;
     border: 1px solid rgba(140, 140, 140, 0.25);
+
+    top: -1px;
 }
 
 .salt-slider .track {
@@ -190,5 +191,7 @@ const dragEnd = () => {
     height: var(--salt-slider-track-height);
     padding-right: var(--salt-slider-track-height);
     border-radius: var(--salt-slider-track-height);
+
+    margin-left: 1px;
 }
 </style>


### PR DESCRIPTION
* fix: Dialog 重做，完全依赖原生 dialog 实现遮罩层修复各种层级问题
* fix: 修复Slider 左上角有部分背景色没有完全覆盖的问题
* feat: RippleEffect 现在会开放一个 window.SaltUI.clearAllRippleAnimate 方法，用以主动清除当前所有波纹动画，从而解决当页面跳转后并返回时，效果会继续播放的问题